### PR TITLE
Fixes And New Analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This repo contains the code to build the Rhinobyte tools libraries for .NET
 
 ## Libraries/Projects
 
+### [Rhinobyte.CodeAnalysis.NetAnalyzers](/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Package/README.md)
 
+[![NuGet version (Rhinobyte.CodeAnalysis.NetAnalyzers)](https://img.shields.io/nuget/v/Rhinobyte.CodeAnalysis.NetAnalyzers.svg?style=flat)](https://www.nuget.org/packages/Rhinobyte.CodeAnalysis.NetAnalyzers/)
 
 ## Contributing
 

--- a/Rhinobyte.Tools.sln
+++ b/Rhinobyte.Tools.sln
@@ -62,6 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{9DDDF270
 		docs\codeanalysis\rules\RBCS0001.md = docs\codeanalysis\rules\RBCS0001.md
 		docs\codeanalysis\rules\RBCS0002.md = docs\codeanalysis\rules\RBCS0002.md
 		docs\codeanalysis\rules\RBCS0003.md = docs\codeanalysis\rules\RBCS0003.md
+		docs\codeanalysis\rules\RBCS0004.md = docs\codeanalysis\rules\rbcs0004.md
+		docs\codeanalysis\rules\RBCS0010.md = docs\codeanalysis\rules\rbcs0010.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeAnalysis", "CodeAnalysis", "{046E0E5B-98C9-429C-A27A-DB84654E9A62}"

--- a/Rhinobyte.Tools.sln
+++ b/Rhinobyte.Tools.sln
@@ -59,10 +59,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{52449E6A-0
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{9DDDF270-B0E9-49E8-98D2-888BFE29F6BD}"
 	ProjectSection(SolutionItems) = preProject
-		docs\codeanalysis\rules\RBCS0001.md = docs\codeanalysis\rules\RBCS0001.md
-		docs\codeanalysis\rules\RBCS0002.md = docs\codeanalysis\rules\RBCS0002.md
-		docs\codeanalysis\rules\RBCS0003.md = docs\codeanalysis\rules\RBCS0003.md
+		docs\codeanalysis\rules\RBCS0001.md = docs\codeanalysis\rules\rbcs0001.md
+		docs\codeanalysis\rules\RBCS0002.md = docs\codeanalysis\rules\rbcs0002.md
+		docs\codeanalysis\rules\RBCS0003.md = docs\codeanalysis\rules\rbcs0003.md
 		docs\codeanalysis\rules\RBCS0004.md = docs\codeanalysis\rules\rbcs0004.md
+		docs\codeanalysis\rules\RBCS0005.md = docs\codeanalysis\rules\rbcs0005.md
 		docs\codeanalysis\rules\RBCS0010.md = docs\codeanalysis\rules\rbcs0010.md
 	EndProjectSection
 EndProject

--- a/docs/codeanalysis/rules/rbcs0001.md
+++ b/docs/codeanalysis/rules/rbcs0001.md
@@ -70,3 +70,5 @@ Use the following option to configure member types into grouping and their respe
 
 - [RBCS0002: Type members within the same group should be ordered correctly](RBCS0002.md)
 - [RBCS0003: Member assignments in an object initializer are ordered correctly](RBCS0003.md)
+- [RBCS0004: Order enum member names alphabetically](RBCS0004.md)
+- [RBCS0005: Order method parameters alphabetically](RBCS0005.md)

--- a/docs/codeanalysis/rules/rbcs0001.md
+++ b/docs/codeanalysis/rules/rbcs0001.md
@@ -20,7 +20,9 @@ dev_langs:
 |-|-|
 | **Rule ID** |RBCS0001|
 | **Category** |Maintainability|
-| **Fix is breaking or non-breaking** |Non-breaking|
+| **Fix is breaking or non-breaking** |Non-breaking†|
+
+† Can be breaking if the member information is consumed via reflection.
 
 ## Cause
 

--- a/docs/codeanalysis/rules/rbcs0002.md
+++ b/docs/codeanalysis/rules/rbcs0002.md
@@ -64,3 +64,5 @@ By default no property names are ordered first.
 
 - [RBCS0001: Type members should be ordered by group](RBCS0001.md)
 - [RBCS0003: Member assignments in an object initializer are ordered correctly](RBCS0003.md)
+- [RBCS0004: Enum member names are ordered alphabetically](RBCS0004.md)
+- [RBCS0005: Order method parameters alphabetically](RBCS0005.md)

--- a/docs/codeanalysis/rules/rbcs0002.md
+++ b/docs/codeanalysis/rules/rbcs0002.md
@@ -20,7 +20,9 @@ dev_langs:
 |-|-|
 | **Rule ID** |RBCS0002|
 | **Category** |Maintainability|
-| **Fix is breaking or non-breaking** |Non-breaking|
+| **Fix is breaking or non-breaking** |Non-breaking†|
+
+† Can be breaking if the member information is consumed via reflection.
 
 ## Cause
 

--- a/docs/codeanalysis/rules/rbcs0003.md
+++ b/docs/codeanalysis/rules/rbcs0003.md
@@ -64,3 +64,5 @@ By default no property names are ordered first.
 
 - [RBCS0001: Type members should be ordered by group](RBCS0001.md)
 - [RBCS0002: Type members within the same group should be ordered correctly](RBCS0002.md)
+- [RBCS0004: Enum member names are ordered alphabetically](RBCS0004.md)
+- [RBCS0005: Order method parameters alphabetically](RBCS0005.md)

--- a/docs/codeanalysis/rules/rbcs0004.md
+++ b/docs/codeanalysis/rules/rbcs0004.md
@@ -1,0 +1,57 @@
+<!--
+---
+title: "RBCS0004: Enum member names are ordered alphabetically (code analysis)"
+description: "Learn about code analysis rule RBCS0004: Enum member names are ordered alphabetically"
+f1_keywords:
+- RBCS0004
+- EnumMemberNamesOrderedAlphabetically
+helpviewer_keywords:
+- EnumMemberNamesOrderedAlphabetically
+- RBCS0004
+author: ryanthomas
+dev_langs:
+- CSharp
+---
+-->
+
+# RBCS0004: Enum member names are ordered alphabetically
+
+| | Value |
+|-|-|
+| **Rule ID** |RBCS0004|
+| **Category** |Maintainability|
+| **Fix is breaking or non-breaking** |Breaking|
+
+## Cause
+
+You want to order your enum member names alphabetically to make it easier to find a specific member and you're ok with the potentially
+breaking change.
+
+## Rule description
+
+Order enum members alphabetically
+
+```csharp
+public enum ExampleEnum
+{
+    Alpha,
+    Bravo,
+    Charlie,
+    Golf,
+    Zulu
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, re-order the enum members alphabetically.
+
+## When to suppress warnings
+
+It is safe to suppress these warnings when there are legitimate reasons to deviate from the agreed upon ordering.
+
+## Related rules
+
+- [RBCS0001: Type members should be ordered by group](RBCS0001.md)
+- [RBCS0002: Type members within the same group should be ordered correctly](RBCS0002.md)
+- [RBCS0003: Member assignments in an object initializer are ordered correctly](RBCS0003.md)

--- a/docs/codeanalysis/rules/rbcs0004.md
+++ b/docs/codeanalysis/rules/rbcs0004.md
@@ -55,3 +55,4 @@ It is safe to suppress these warnings when there are legitimate reasons to devia
 - [RBCS0001: Type members should be ordered by group](RBCS0001.md)
 - [RBCS0002: Type members within the same group should be ordered correctly](RBCS0002.md)
 - [RBCS0003: Member assignments in an object initializer are ordered correctly](RBCS0003.md)
+- [RBCS0005: Order method parameters alphabetically](RBCS0005.md)

--- a/docs/codeanalysis/rules/rbcs0005.md
+++ b/docs/codeanalysis/rules/rbcs0005.md
@@ -1,0 +1,47 @@
+<!--
+---
+title: "RBCS0005: Method parameters are ordered alphabetically (code analysis)"
+description: "Learn about code analysis rule RBCS0005: Method parameters are ordered alphabetically"
+f1_keywords:
+- RBCS0005
+- MethodParametersOrderedAlphabetically
+helpviewer_keywords:
+- MethodParametersOrderedAlphabetically
+- RBCS0005
+author: ryanthomas
+dev_langs:
+- CSharp
+---
+-->
+
+# RBCS0005: Method parameters are ordered alphabetically
+
+| | Value |
+|-|-|
+| **Rule ID** |RBCS0005|
+| **Category** |Maintainability|
+| **Fix is breaking or non-breaking** |Breaking|
+
+## Cause
+
+You want to order your method parameters to make it easier to find a specific member and you're ok with the potentially
+breaking change.
+
+## Rule description
+
+Order method parameters alphabetically
+
+## How to fix violations
+
+To fix a violation of this rule, re-order the method parameters alphabetically.
+
+## When to suppress warnings
+
+It is safe to suppress these warnings when there are legitimate reasons to deviate from the agreed upon ordering.
+
+## Related rules
+
+- [RBCS0001: Type members should be ordered by group](RBCS0001.md)
+- [RBCS0002: Type members within the same group should be ordered correctly](RBCS0002.md)
+- [RBCS0003: Member assignments in an object initializer are ordered correctly](RBCS0003.md)
+- [RBCS0004: Enum member names are ordered alphabetically](RBCS0004.md)

--- a/docs/codeanalysis/rules/rbcs0010.md
+++ b/docs/codeanalysis/rules/rbcs0010.md
@@ -1,0 +1,50 @@
+<!--
+---
+title: "RBCS0010: Use explicit parameter name for optional argument (code analysis)"
+description: "Learn about code analysis rule RBCS0010: Use explicit parameter name for optional argument"
+f1_keywords:
+- RBCS0010
+- UseExplicitNameForOptionalMethodParameters
+helpviewer_keywords:
+- UseExplicitNameForOptionalMethodParameters
+- RBCS0010
+author: ryanthomas
+dev_langs:
+- CSharp
+---
+-->
+
+# RBCS0010: Use explicit parameter name for optional argument
+
+| | Value |
+|-|-|
+| **Rule ID** |RBCS0010|
+| **Category** |Maintainability|
+| **Fix is breaking or non-breaking** |Non-breaking|
+
+## Cause
+
+When methods have multiple optional parameters, it is possible to unintentionally modify the method signature in a way that introduces
+a breaking change that will not be caught by the compiler. By using explicit parameter names for optional arguments, you can avoid introducing
+such runtime errors.
+
+## Rule description
+
+Use explicit parameter name for optional argument
+
+```csharp
+public void AwsomeMethod(int param1, int param2, int param3Optional = 3, int param4Optional = 4, int param5Optional = 5)
+{
+    // Method implementation
+}
+
+AwsomeMethod(1, 2, param3Optional: 3, param4Optional: 4)
+```
+
+## How to fix violations
+
+To fix a violation of this rule, add the explicit parameter name using name colon synatx for the optional arguments.
+
+## When to suppress warnings
+
+N/A

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -79,6 +79,15 @@ namespace Rhinobyte.CodeAnalysis.NetAnalyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reorder the method parameters.
+        /// </summary>
+        internal static string ParameterOrderCodeFixTitle {
+            get {
+                return ResourceManager.GetString("ParameterOrderCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use explicit name for optional parameters.
         /// </summary>
         internal static string UseExplicitNameForOptionalParametersCodeFixTitle {

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/CodeFixResources.resx
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/CodeFixResources.resx
@@ -124,6 +124,9 @@
     <value>Reorder the members</value>
     <comment>The title of the code fix.</comment>
   </data>
+  <data name="ParameterOrderCodeFixTitle" xml:space="preserve">
+    <value>Reorder the method parameters</value>
+  </data>
   <data name="UseExplicitNameForOptionalParametersCodeFixTitle" xml:space="preserve">
     <value>Use explicit name for optional parameters</value>
   </data>

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/MembersOrderedCorrectlyAnalyzerCodeFixProvider.cs
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/MembersOrderedCorrectlyAnalyzerCodeFixProvider.cs
@@ -27,7 +27,8 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 			MembersOrderedCorrectlyAnalyzer.RBCS0001,
 			MembersOrderedCorrectlyAnalyzer.RBCS0002,
 			MembersOrderedCorrectlyAnalyzer.RBCS0003,
-			MembersOrderedCorrectlyAnalyzer.RBCS0004
+			MembersOrderedCorrectlyAnalyzer.RBCS0004,
+			MembersOrderedCorrectlyAnalyzer.RBCS0005
 		];
 
 	/// <summary>
@@ -128,12 +129,31 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 		List<Diagnostic>? enumDiagnosticsToFix = null;
 		List<EnumDeclarationSyntax>? enumDeclarationsToFix = null;
 
+		List<Diagnostic>? parameterOrderDiagnosticsToFix = null;
+		List<ParameterListSyntax>? parameterListSyntaxToFix = null;
+
 		List<Diagnostic>? typeMemberDiagnosticsToFix = null;
 		List<TypeDeclarationSyntax>? typeDeclarationsToFix = null;
 
 		foreach (var diagnosticToFix in context.Diagnostics)
 		{
 			var diagnosticSpan = diagnosticToFix.Location.SourceSpan;
+
+			if (diagnosticToFix.Id == MembersOrderedCorrectlyAnalyzer.RBCS0001
+				|| diagnosticToFix.Id == MembersOrderedCorrectlyAnalyzer.RBCS0002)
+			{
+				var typeDeclarationSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+				if (typeDeclarationSyntaxNode is not null)
+				{
+					typeMemberDiagnosticsToFix ??= [];
+					typeMemberDiagnosticsToFix.Add(diagnosticToFix);
+
+					typeDeclarationsToFix ??= [];
+					typeDeclarationsToFix.Add(typeDeclarationSyntaxNode);
+				}
+
+				continue;
+			}
 
 			if (diagnosticToFix.Id == MembersOrderedCorrectlyAnalyzer.RBCS0003)
 			{
@@ -166,26 +186,32 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 				continue;
 			}
 
-			var typeDeclarationSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
-			if (typeDeclarationSyntaxNode is not null)
+			if (diagnosticToFix.Id == MembersOrderedCorrectlyAnalyzer.RBCS0004)
 			{
-				typeMemberDiagnosticsToFix ??= [];
-				typeMemberDiagnosticsToFix.Add(diagnosticToFix);
+				var enumDeclarationSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<EnumDeclarationSyntax>().FirstOrDefault();
+				if (enumDeclarationSyntaxNode is not null)
+				{
+					enumDiagnosticsToFix ??= [];
+					enumDiagnosticsToFix.Add(diagnosticToFix);
 
-				typeDeclarationsToFix ??= [];
-				typeDeclarationsToFix.Add(typeDeclarationSyntaxNode);
+					enumDeclarationsToFix ??= [];
+					enumDeclarationsToFix.Add(enumDeclarationSyntaxNode);
 
-				continue;
+					continue;
+				}
 			}
 
-			var enumDeclarationSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<EnumDeclarationSyntax>().FirstOrDefault();
-			if (enumDeclarationSyntaxNode is not null)
+			if (diagnosticToFix.Id == MembersOrderedCorrectlyAnalyzer.RBCS0005)
 			{
-				enumDiagnosticsToFix ??= [];
-				enumDiagnosticsToFix.Add(diagnosticToFix);
+				var parameterListSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<ParameterListSyntax>().FirstOrDefault();
+				if (parameterListSyntaxNode is not null)
+				{
+					parameterOrderDiagnosticsToFix ??= [];
+					parameterOrderDiagnosticsToFix.Add(diagnosticToFix);
 
-				enumDeclarationsToFix ??= [];
-				enumDeclarationsToFix.Add(enumDeclarationSyntaxNode);
+					parameterListSyntaxToFix ??= [];
+					parameterListSyntaxToFix.Add(parameterListSyntaxNode);
+				}
 
 				continue;
 			}
@@ -235,6 +261,25 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 			// Only need to register one document fix for the enum member re-order, so pass it all the individual member diagnostics that are being fixed
 			context.RegisterCodeFix(codeFixAction, enumDiagnosticsToFix);
 		}
+
+		if (parameterOrderDiagnosticsToFix is not null && parameterListSyntaxToFix is not null)
+		{
+			// TODO: Support custom options to order specific names first?
+
+			var codeFixAction = CodeAction.Create(
+				title: CodeFixResources.ParameterOrderCodeFixTitle,
+				createChangedDocument: (cancellationToken) => ReorderMethodParametersAsync(
+					context.Document,
+					parameterListSyntaxToFix,
+					cancellationToken
+				),
+				equivalenceKey: nameof(CodeFixResources.ParameterOrderCodeFixTitle)
+			);
+
+			// Only need to register one document fix for all of the parameters in the parameter list to re-order, s
+			// so pass it all the individual parameter diagnostics that are being fixed
+			context.RegisterCodeFix(codeFixAction, parameterOrderDiagnosticsToFix);
+		}
 	}
 
 	private static async Task<Document> ReorderEnumMembersAsync(
@@ -246,16 +291,11 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 		if (oldRoot is null)
 			return document;
 
-#if DEBUG
-		var oldSyntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-		var oldSyntaxTreeContent = oldSyntaxTree?.ToString();
-#endif
-
 		var newRoot = oldRoot;
 		foreach (var enumDeclaration in enumDeclarationsToFix)
 		{
 			var reorderedMembers = enumDeclaration.Members
-				.OrderBy(memberDeclarationSyntax => memberDeclarationSyntax.Identifier.Text)
+				.OrderBy(memberDeclarationSyntax => memberDeclarationSyntax.Identifier.ValueText ?? memberDeclarationSyntax.Identifier.Text)
 				.ToList();
 
 			var separators = enumDeclaration.Members.GetSeparators();
@@ -265,6 +305,44 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 			var newEnumDeclaration = enumDeclaration.WithMembers(newEnumMemberOrder);
 
 			newRoot = newRoot.ReplaceNode(enumDeclaration, newEnumDeclaration);
+		}
+
+		if (newRoot == oldRoot)
+			return document;
+
+#if DEBUG
+		var newDocument = document.WithSyntaxRoot(newRoot);
+		var newSyntaxTree = await newDocument.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+		var newSyntaxTreeContent = newSyntaxTree?.ToString();
+		return newDocument;
+#else
+		return document.WithSyntaxRoot(newRoot);
+#endif
+
+	}
+
+	private static async Task<Document> ReorderMethodParametersAsync(
+		Document document,
+		ICollection<ParameterListSyntax> parameterListsToFix,
+		CancellationToken cancellationToken)
+	{
+		var oldRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+		if (oldRoot is null)
+			return document;
+
+		var newRoot = oldRoot;
+		foreach (var parameterList in parameterListsToFix)
+		{
+			var reorderedParameters = parameterList.Parameters
+				.OrderBy(parameterSyntax => parameterSyntax.Identifier.ValueText ?? parameterSyntax.Identifier.Text)
+				.ToList();
+
+			var separators = parameterList.Parameters.GetSeparators();
+
+			var newParameters = SyntaxFactory.SeparatedList(reorderedParameters, separators);
+			var newParameterList = parameterList.WithParameters(newParameters);
+
+			newRoot = newRoot.ReplaceNode(parameterList, newParameterList);
 		}
 
 		if (newRoot == oldRoot)

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/MembersOrderedCorrectlyAnalyzerCodeFixProvider.cs
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/MembersOrderedCorrectlyAnalyzerCodeFixProvider.cs
@@ -23,7 +23,12 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 {
 	/// <inheritdoc/>
 	public sealed override ImmutableArray<string> FixableDiagnosticIds
-		=> [MembersOrderedCorrectlyAnalyzer.RBCS0001, MembersOrderedCorrectlyAnalyzer.RBCS0002, MembersOrderedCorrectlyAnalyzer.RBCS0003];
+		=> [
+			MembersOrderedCorrectlyAnalyzer.RBCS0001,
+			MembersOrderedCorrectlyAnalyzer.RBCS0002,
+			MembersOrderedCorrectlyAnalyzer.RBCS0003,
+			MembersOrderedCorrectlyAnalyzer.RBCS0004
+		];
 
 	/// <summary>
 	/// Count the number of newlines and non-whitespace trivia in the provided trivia list.
@@ -120,6 +125,9 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 		if (root is null)
 			return;
 
+		List<Diagnostic>? enumDiagnosticsToFix = null;
+		List<EnumDeclarationSyntax>? enumDeclarationsToFix = null;
+
 		List<Diagnostic>? typeMemberDiagnosticsToFix = null;
 		List<TypeDeclarationSyntax>? typeDeclarationsToFix = null;
 
@@ -158,14 +166,29 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 				continue;
 			}
 
-			var typeDeclarationSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().First();
-			if (typeDeclarationSyntaxNode is null)
-				continue;
+			var typeDeclarationSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+			if (typeDeclarationSyntaxNode is not null)
+			{
+				typeMemberDiagnosticsToFix ??= [];
+				typeMemberDiagnosticsToFix.Add(diagnosticToFix);
 
-			typeMemberDiagnosticsToFix ??= [];
-			typeMemberDiagnosticsToFix.Add(diagnosticToFix);
-			typeDeclarationsToFix ??= [];
-			typeDeclarationsToFix.Add(typeDeclarationSyntaxNode);
+				typeDeclarationsToFix ??= [];
+				typeDeclarationsToFix.Add(typeDeclarationSyntaxNode);
+
+				continue;
+			}
+
+			var enumDeclarationSyntaxNode = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<EnumDeclarationSyntax>().FirstOrDefault();
+			if (enumDeclarationSyntaxNode is not null)
+			{
+				enumDiagnosticsToFix ??= [];
+				enumDiagnosticsToFix.Add(diagnosticToFix);
+
+				enumDeclarationsToFix ??= [];
+				enumDeclarationsToFix.Add(enumDeclarationSyntaxNode);
+
+				continue;
+			}
 		}
 
 		if (typeMemberDiagnosticsToFix is not null && typeDeclarationsToFix is not null)
@@ -194,6 +217,68 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 			// Only need to register one document fix for the type member re-order, so pass it all the individual member diagnostics that are being fixed
 			context.RegisterCodeFix(codeFixAction, typeMemberDiagnosticsToFix);
 		}
+
+		if (enumDiagnosticsToFix is not null && enumDeclarationsToFix is not null)
+		{
+			// TODO: Support custom options to order specific names first?
+
+			var codeFixAction = CodeAction.Create(
+				title: CodeFixResources.MemberOrderCodeFixTitle,
+				createChangedDocument: (cancellationToken) => ReorderEnumMembersAsync(
+					context.Document,
+					enumDeclarationsToFix,
+					cancellationToken
+				),
+				equivalenceKey: nameof(CodeFixResources.MemberOrderCodeFixTitle)
+			);
+
+			// Only need to register one document fix for the enum member re-order, so pass it all the individual member diagnostics that are being fixed
+			context.RegisterCodeFix(codeFixAction, enumDiagnosticsToFix);
+		}
+	}
+
+	private static async Task<Document> ReorderEnumMembersAsync(
+		Document document,
+		ICollection<EnumDeclarationSyntax> enumDeclarationsToFix,
+		CancellationToken cancellationToken)
+	{
+		var oldRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+		if (oldRoot is null)
+			return document;
+
+#if DEBUG
+		var oldSyntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+		var oldSyntaxTreeContent = oldSyntaxTree?.ToString();
+#endif
+
+		var newRoot = oldRoot;
+		foreach (var enumDeclaration in enumDeclarationsToFix)
+		{
+			var reorderedMembers = enumDeclaration.Members
+				.OrderBy(memberDeclarationSyntax => memberDeclarationSyntax.Identifier.Text)
+				.ToList();
+
+			var separators = enumDeclaration.Members.GetSeparators();
+
+			var newEnumMemberOrder = SyntaxFactory.SeparatedList(reorderedMembers, separators);
+
+			var newEnumDeclaration = enumDeclaration.WithMembers(newEnumMemberOrder);
+
+			newRoot = newRoot.ReplaceNode(enumDeclaration, newEnumDeclaration);
+		}
+
+		if (newRoot == oldRoot)
+			return document;
+
+#if DEBUG
+		var newDocument = document.WithSyntaxRoot(newRoot);
+		var newSyntaxTree = await newDocument.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+		var newSyntaxTreeContent = newSyntaxTree?.ToString();
+		return newDocument;
+#else
+		return document.WithSyntaxRoot(newRoot);
+#endif
+
 	}
 
 	private static async Task<Document> ReorderObjectInitializerMemberAssignmentsAsync(

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerReleases.Shipped.md
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerReleases.Shipped.md
@@ -9,6 +9,7 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 RBCS0001|  Maintainability  |  Info    | MembersOrderedCorrectlyAnalyzer, [RBCS0001 Documentation](../../../docs/codeanalysis/rules/rbcs0001.md)
 RBCS0002|  Maintainability  |  Info    | MembersOrderedCorrectlyAnalyzer, [RBCS0002 Documentation](../../../docs/codeanalysis/rules/rbcs0002.md)
-RBCS0003|  Maintainability  |  Info    | MembersOrderedCorrectlyAnalyzer, [RBCS0003 Documentation](../../../docs/codeanalysis/rules/rbcs0003.md)
-RBCS0003|  Maintainability  |  Hidden  | MembersOrderedCorrectlyAnalyzer, [RBCS0004 Documentation](../../../docs/codeanalysis/rules/rbcs0004.md)
+RBCS0003|  Maintainability  |  Info    | MembersOrderedCorrectlyAnalyzer (Object Initializers), [RBCS0003 Documentation](../../../docs/codeanalysis/rules/rbcs0003.md)
+RBCS0004|  Maintainability  |  Disabled  | MembersOrderedCorrectlyAnalyzer (Enum Member Names), [RBCS0004 Documentation](../../../docs/codeanalysis/rules/rbcs0004.md)
+RBCS0005|  Maintainability  |  Disabled  | MembersOrderedCorrectlyAnalyzer (Method Parameters), [RBCS0005 Documentation](../../../docs/codeanalysis/rules/rbcs0005.md)
 RBCS0010|  Maintainability  |  Info    | UseExplicitNameForOptionalMethodParametersAnalyzer, [RBCS0010 Documentation](../../../docs/codeanalysis/rules/rbcs0010.md)

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerReleases.Shipped.md
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerReleases.Shipped.md
@@ -10,4 +10,5 @@ Rule ID | Category | Severity | Notes
 RBCS0001|  Maintainability  |  Info    | MembersOrderedCorrectlyAnalyzer, [RBCS0001 Documentation](../../../docs/codeanalysis/rules/rbcs0001.md)
 RBCS0002|  Maintainability  |  Info    | MembersOrderedCorrectlyAnalyzer, [RBCS0002 Documentation](../../../docs/codeanalysis/rules/rbcs0002.md)
 RBCS0003|  Maintainability  |  Info    | MembersOrderedCorrectlyAnalyzer, [RBCS0003 Documentation](../../../docs/codeanalysis/rules/rbcs0003.md)
+RBCS0003|  Maintainability  |  Hidden  | MembersOrderedCorrectlyAnalyzer, [RBCS0004 Documentation](../../../docs/codeanalysis/rules/rbcs0004.md)
 RBCS0010|  Maintainability  |  Info    | UseExplicitNameForOptionalMethodParametersAnalyzer, [RBCS0010 Documentation](../../../docs/codeanalysis/rules/rbcs0010.md)

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.Designer.cs
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.Designer.cs
@@ -169,6 +169,33 @@ namespace Rhinobyte.CodeAnalysis.NetAnalyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Order method parameters alphabetically..
+        /// </summary>
+        internal static string RBCS_0005_AnalyzerDescription {
+            get {
+                return ResourceManager.GetString("RBCS_0005_AnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Order method parameters alphabetically.
+        /// </summary>
+        internal static string RBCS_0005_AnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("RBCS_0005_AnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Order method parameters alphabetically.
+        /// </summary>
+        internal static string RBCS_0005_AnalyzerTitle {
+            get {
+                return ResourceManager.GetString("RBCS_0005_AnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Using explicitly named optional parameters can help with code maintainability and help guard against errors and unintended behavior changes..
         /// </summary>
         internal static string RBCS_0010_AnalyzerDescription {

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.Designer.cs
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.Designer.cs
@@ -142,6 +142,33 @@ namespace Rhinobyte.CodeAnalysis.NetAnalyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Our code fix provider can automatically alphabetize your enum member names. Use with caution..
+        /// </summary>
+        internal static string RBCS_0004_AnalyzerDescription {
+            get {
+                return ResourceManager.GetString("RBCS_0004_AnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Order enum member names alphabetically (potentially breaking change).
+        /// </summary>
+        internal static string RBCS_0004_AnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("RBCS_0004_AnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Order enum members alphabetically.
+        /// </summary>
+        internal static string RBCS_0004_AnalyzerTitle {
+            get {
+                return ResourceManager.GetString("RBCS_0004_AnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Using explicitly named optional parameters can help with code maintainability and help guard against errors and unintended behavior changes..
         /// </summary>
         internal static string RBCS_0010_AnalyzerDescription {

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.resx
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.resx
@@ -147,6 +147,15 @@
   <data name="RBCS_0003_AnalyzerTitle" xml:space="preserve">
     <value>Member assignments in an object initializer are ordered correctly</value>
   </data>
+  <data name="RBCS_0004_AnalyzerDescription" xml:space="preserve">
+    <value>Our code fix provider can automatically alphabetize your enum member names. Use with caution.</value>
+  </data>
+  <data name="RBCS_0004_AnalyzerMessageFormat" xml:space="preserve">
+    <value>Order enum member names alphabetically (potentially breaking change)</value>
+  </data>
+  <data name="RBCS_0004_AnalyzerTitle" xml:space="preserve">
+    <value>Order enum members alphabetically</value>
+  </data>
   <data name="RBCS_0010_AnalyzerDescription" xml:space="preserve">
     <value>Using explicitly named optional parameters can help with code maintainability and help guard against errors and unintended behavior changes.</value>
   </data>

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.resx
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/AnalyzerResources.resx
@@ -156,6 +156,15 @@
   <data name="RBCS_0004_AnalyzerTitle" xml:space="preserve">
     <value>Order enum members alphabetically</value>
   </data>
+  <data name="RBCS_0005_AnalyzerDescription" xml:space="preserve">
+    <value>Order method parameters alphabetically.</value>
+  </data>
+  <data name="RBCS_0005_AnalyzerMessageFormat" xml:space="preserve">
+    <value>Order method parameters alphabetically</value>
+  </data>
+  <data name="RBCS_0005_AnalyzerTitle" xml:space="preserve">
+    <value>Order method parameters alphabetically</value>
+  </data>
   <data name="RBCS_0010_AnalyzerDescription" xml:space="preserve">
     <value>Using explicitly named optional parameters can help with code maintainability and help guard against errors and unintended behavior changes.</value>
   </data>

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/AnalyzerOptionsTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/AnalyzerOptionsTests.cs
@@ -57,7 +57,7 @@ dotnet_code_quality.RBCS0002.property_names_to_order_first = Id
 ")
 		};
 
-		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, editorConfigSettings);
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, analyzerConfigFiles: editorConfigSettings);
 		//await VerifyCS.VerifyCodeFixAsync(testContent, codeFixResult);
 	}
 
@@ -93,7 +93,7 @@ dotnet_code_quality.RBCS0002.property_names_to_order_first = Id
 ")
 		};
 
-		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, editorConfigSettings);
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, analyzerConfigFiles: editorConfigSettings);
 	}
 
 
@@ -143,7 +143,7 @@ dotnet_code_quality.RBCS0001.type_members_group_order = Constants,StaticReadonly
 ")
 		};
 
-		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, editorConfigSettings);
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, analyzerConfigFiles: editorConfigSettings);
 		//await VerifyCS.VerifyCodeFixAsync(testContent, codeFixResult);
 	}
 

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderCorrectlyAnalyzerUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderCorrectlyAnalyzerUnitTests.cs
@@ -120,6 +120,20 @@ public class MembersOrderCorrectlyAnalyzerUnitTests
 	}
 
 	[TestMethod]
+	public async Task MembersOrderedCorrectlyAnalyzer_enum_members_diagnostic()
+	{
+		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);
+
+		var expectedDiagnosticResults = new DiagnosticResult[]
+		{
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.Rule_RBCS_0004).WithSpan(13, 2, 13, 8).WithArguments("ValueB"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.Rule_RBCS_0004).WithSpan(15, 2, 15, 8).WithArguments("ValueD"),
+		};
+
+		await VerifyCS.VerifyAnalyzerAsync(testContent, expectedDiagnosticResults);
+	}
+
+	[TestMethod]
 	public async Task MembersOrderedCorrectlyAnalyzer_ignores_primary_constructor()
 	{
 		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderCorrectlyAnalyzerUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderCorrectlyAnalyzerUnitTests.cs
@@ -47,8 +47,11 @@ public class MembersOrderCorrectlyAnalyzerUnitTests
 			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0002).WithSpan(87, 16, 87, 23).WithArguments("AMethod"),
 		};
 
-		await VerifyCS.VerifyAnalyzerAsync(testContent, expectedDiagnosticResults);
-		//await VerifyCS.VerifyAnalyzerAsync(testContent);
+		await VerifyCS.VerifyAnalyzerAsync(
+			testContent,
+			expected: expectedDiagnosticResults,
+			disabledDiagnostics: [MembersOrderedCorrectlyAnalyzer.RBCS0005]
+		);
 	}
 
 	[TestMethod]

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderCorrectlyAnalyzerUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderCorrectlyAnalyzerUnitTests.cs
@@ -118,4 +118,29 @@ public class MembersOrderCorrectlyAnalyzerUnitTests
 
 		await VerifyCS.VerifyAnalyzerAsync(testContent);
 	}
+
+	[TestMethod]
+	public async Task MembersOrderedCorrectlyAnalyzer_ignores_primary_constructor()
+	{
+		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);
+
+		var expectedDiagnosticResults = new DiagnosticResult[]
+		{
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0002).WithSpan(13, 23, 13, 34).WithArguments("ConstantOne"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0002).WithSpan(17, 24, 17, 31).WithArguments("_fieldB"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0002).WithSpan(28, 15, 28, 24).WithArguments("IsEnabled"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0002).WithSpan(35, 28, 35, 44).WithArguments("DoSomethingAsync"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0001).WithSpan(40, 17, 40, 35).WithArguments("OutOfOrderProperty"),
+		};
+
+		await VerifyCS.VerifyAnalyzerAsync(testContent, expectedDiagnosticResults);
+	}
+
+	[TestMethod]
+	public async Task MembersOrderedCorrectlyAnalyzer_ignores_primary_constructor2()
+	{
+		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);
+
+		await VerifyCS.VerifyAnalyzerAsync(testContent);
+	}
 }

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
@@ -114,4 +114,22 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests
 		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult);
 		//await VerifyCS.VerifyCodeFixAsync(testContent, codeFixResult);
 	}
+
+
+	[TestMethod]
+	public async Task MembersOrderedCorrectlyCodeFixer_correctly_reorders_with_primary_constructor()
+	{
+		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);
+		var codeFixResult = await TestHelper.GetTestCodeFixResultFileAsync(CancellationTokenForTest);
+
+		var expectedDiagnosticResults = new DiagnosticResult[]
+		{
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0001).WithSpan(26, 23, 26, 42).WithArguments("_outOfOrderedField1"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0001).WithSpan(28, 9, 28, 47).WithArguments(".ctor"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0001).WithSpan(39, 16, 39, 34).WithArguments("OutOfOrderProperty"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RuleRBCS0001).WithSpan(41, 14, 41, 33).WithArguments("_outOfOrderedField2"),
+		};
+
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult);
+	}
 }

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
@@ -132,4 +132,21 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests
 
 		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult);
 	}
+
+	[TestMethod]
+	public async Task MembersOrderedCorrectlyCodeFixer_reorders_enum_members()
+	{
+		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);
+		var codeFixResult = await TestHelper.GetTestCodeFixResultFileAsync(CancellationTokenForTest);
+
+		var expectedDiagnosticResults = new DiagnosticResult[]
+		{
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.Rule_RBCS_0004).WithSpan(13, 2, 13, 7).WithArguments("Bravo"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.Rule_RBCS_0004).WithSpan(15, 2, 15, 7).WithArguments("Delta"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.Rule_RBCS_0004).WithSpan(34, 2, 34, 7).WithArguments("Bravo"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.Rule_RBCS_0004).WithSpan(44, 2, 44, 7).WithArguments("Delta"),
+		};
+
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult);
+	}
 }

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using VerifyCS = Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.CSharpCodeFixVerifier<
@@ -148,5 +149,32 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests
 		};
 
 		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult);
+	}
+
+	[TestMethod]
+	public async Task MembersOrderedCorrectlyCodeFixer_reorders_method_parameters()
+	{
+		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);
+		var codeFixResult = await TestHelper.GetTestCodeFixResultFileAsync(CancellationTokenForTest);
+
+		var expectedDiagnosticResults = new DiagnosticResult[]
+		{
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0005).WithSpan(9, 40, 11, 15).WithArguments("alpha"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0005).WithSpan(20, 35, 25, 16).WithArguments("bravo, delta"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0005).WithSpan(41, 25, 41, 46).WithArguments("alpha"),
+		};
+
+		var editorConfigSettings = new List<(string, string)>()
+		{
+			("/.EditorConfig", $@"root = true
+
+[*]
+dotnet_diagnostic.RBCS0001.severity = none
+dotnet_diagnostic.RBCS0002.severity = none
+dotnet_diagnostic.RBCS0003.severity = none
+")
+		};
+
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, analyzerConfigFiles: editorConfigSettings);
 	}
 }

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/ObjectInitializerMemberOrderUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/ObjectInitializerMemberOrderUnitTests.cs
@@ -65,6 +65,6 @@ dotnet_code_quality.RBCS0002.property_names_to_order_first = Id
 ")
 		};
 
-		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, editorConfigSettings);
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, analyzerConfigFiles: editorConfigSettings);
 	}
 }

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyAnalyzer_enum_members_diagnostic.input.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyAnalyzer_enum_members_diagnostic.input.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public enum ExampleEnumWithIncorrectAlphabeticalOrdering
+{
+	ValueA,
+	ValueC,
+	ValueB,
+	ValueE,
+	ValueD,
+	ValueZ
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyAnalyzer_ignores_primary_constructor.input.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyAnalyzer_ignores_primary_constructor.input.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles
+{
+	public class ExampleClassWithIncorrectAlphabeticalOrdering(
+		string primaryConstructorParam)
+	{
+		public static readonly TimeSpan TimeSpanConstant = TimeSpan.FromMinutes(1);
+		public const string ConstantOne = nameof(ConstantOne);
+
+		private readonly string _fieldA;
+		private bool _fieldE;
+		private readonly int _fieldB;
+		private string _fieldZ;
+
+		public ExampleClassWithIncorrectAlphabeticalOrdering(string primaryConstructorParam, string secondParam)
+			: this(primaryConstructorParam)
+		{
+
+		}
+
+		public bool IsNotValid { get; set; }
+
+		public bool IsEnabled { get; set; }
+
+		public Task<bool> SomethingElseAsync(CancellationToken cancellationToken)
+		{
+			return Task.FromResult(true);
+		}
+
+		public static async Task DoSomethingAsync(CancellationToken cancellationToken)
+		{
+
+		}
+
+		public string OutOfOrderProperty { get; set; }
+	}
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyAnalyzer_ignores_primary_constructor2.input.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyAnalyzer_ignores_primary_constructor2.input.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public class ExampleClassWithIncorrectAlphabeticalOrdering(
+	string primaryConstructorParam)
+{
+	public const string ConstantOne = nameof(ConstantOne);
+
+	// Field and constant should not be flagged as out of order due to the primary constructor above them
+	private readonly string _fieldA;
+
+	public ExampleClassWithIncorrectAlphabeticalOrdering(string primaryConstructorParam, string secondParam)
+		: this(primaryConstructorParam)
+	{
+
+	}
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_correctly_reorders_with_primary_constructor.codefixresult.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_correctly_reorders_with_primary_constructor.codefixresult.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public class ExampleClassWithIncorrectGroupOrdering(
+	string primaryConstructorParam1,
+	string primaryConstructorParam2)
+{
+	public const string ConstantOne = nameof(ConstantOne);
+	public static readonly TimeSpan TimeSpanConstant = TimeSpan.FromMinutes(1);
+
+	public static bool StaticProperty { get; } = true;
+
+	private readonly int _outOfOrderedField1;
+
+	private int _outOfOrderedField2;
+
+	public ExampleClassWithIncorrectGroupOrdering()
+		: this(string.Empty, string.Empty)
+	{
+
+    }
+
+	public ExampleClassWithIncorrectGroupOrdering(bool isEnabled)
+		: this(string.Empty, string.Empty)
+	{
+		IsEnabled = isEnabled;
+	}
+
+	public bool IsEnabled { get; set; }
+
+	public string OutOfOrderProperty { get; set; }
+
+	public static async Task DoSomethingAsync(CancellationToken cancellationToken)
+    {
+
+    }
+
+	public Task<bool> SomethingElseAsync(CancellationToken cancellationToken)
+    {
+		return Task.FromResult(true);
+    }
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_correctly_reorders_with_primary_constructor.input.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_correctly_reorders_with_primary_constructor.input.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public class ExampleClassWithIncorrectGroupOrdering(
+	string primaryConstructorParam1,
+	string primaryConstructorParam2)
+{
+	public const string ConstantOne = nameof(ConstantOne);
+	public static readonly TimeSpan TimeSpanConstant = TimeSpan.FromMinutes(1);
+
+	public static bool StaticProperty { get; } = true;
+
+	public ExampleClassWithIncorrectGroupOrdering()
+		: this(string.Empty, string.Empty)
+	{
+
+    }
+
+	public bool IsEnabled { get; set; }
+
+	private readonly int _outOfOrderedField1;
+
+	public ExampleClassWithIncorrectGroupOrdering(bool isEnabled)
+		: this(string.Empty, string.Empty)
+	{
+		IsEnabled = isEnabled;
+	}
+
+	public static async Task DoSomethingAsync(CancellationToken cancellationToken)
+    {
+
+    }
+
+	public string OutOfOrderProperty { get; set; }
+
+	private int _outOfOrderedField2;
+
+	public Task<bool> SomethingElseAsync(CancellationToken cancellationToken)
+    {
+		return Task.FromResult(true);
+    }
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_enum_members.codefixresult.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_enum_members.codefixresult.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public enum ExampleEnumWithIncorrectAlphabeticalOrdering
+{
+	Alpha = 0,
+	Bravo = 2,
+	Charlie = 1,
+	Delta = 4,
+	Echo = 3,
+	Zulu = 5
+}
+
+public enum ExampleEnumTwo
+{
+	/// <summary>
+	/// Comment for Alpha
+	/// </summary>
+	Alpha = 1,
+
+	/// <summary>
+	/// Comment for Bravo
+	/// </summary>
+	Bravo = 3,
+
+	/// <summary>
+	/// Comment for Charlie
+	/// </summary>
+	Charlie = 2,
+
+	/// <summary>
+	/// Comment for Delta
+	/// </summary>
+	Delta = 5,
+
+	/// <summary>
+	/// Comment for Echo
+	/// </summary>
+	Echo = 4,
+
+	/// <summary>
+	/// Comment for Zulu
+	/// </summary>
+	Zulu = 6
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_enum_members.input.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_enum_members.input.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public enum ExampleEnumWithIncorrectAlphabeticalOrdering
+{
+	Alpha = 0,
+	Charlie = 1,
+	Bravo = 2,
+	Echo = 3,
+	Delta = 4,
+	Zulu = 5
+}
+
+public enum ExampleEnumTwo
+{
+	/// <summary>
+	/// Comment for Alpha
+	/// </summary>
+	Alpha = 1,
+
+	/// <summary>
+	/// Comment for Charlie
+	/// </summary>
+	Charlie = 2,
+
+	/// <summary>
+	/// Comment for Bravo
+	/// </summary>
+	Bravo = 3,
+
+	/// <summary>
+	/// Comment for Echo
+	/// </summary>
+	Echo = 4,
+
+	/// <summary>
+	/// Comment for Delta
+	/// </summary>
+	Delta = 5,
+
+	/// <summary>
+	/// Comment for Zulu
+	/// </summary>
+	Zulu = 6
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_method_parameters.codefixresult.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_method_parameters.codefixresult.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public class ReorderParametersTestClass(
+	string alpha,
+	string zulu)
+{
+	public ReorderParametersTestClass(
+		string alpha,
+		string bravo,
+		string charlie)
+		: this(alpha, "zulu")
+	{ }
+
+	public ReorderParametersTestClass(
+		string alpha,
+		string bravo,
+		string charlie,
+		string delta,
+		string echo)
+		: this(alpha, "zulu")
+	{ }
+
+	public void MethodOne()
+	{
+		// No-op
+	}
+
+	public void MethodTwo(
+		int alpha,
+		int bravo)
+	{
+		// No-op
+	}
+
+	public void MethodThree(int alpha, int zulu)
+	{
+		// No-op
+	}
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_method_parameters.input.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_reorders_method_parameters.input.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public class ReorderParametersTestClass(
+	string zulu,
+	string alpha)
+{
+	public ReorderParametersTestClass(
+		string alpha,
+		string bravo,
+		string charlie)
+		: this(alpha, "zulu")
+	{ }
+
+	public ReorderParametersTestClass(
+		string alpha,
+		string charlie,
+		string bravo,
+		string echo,
+		string delta)
+		: this(alpha, "zulu")
+	{ }
+
+	public void MethodOne()
+	{
+		// No-op
+	}
+
+	public void MethodTwo(
+		int alpha,
+		int bravo)
+	{
+		// No-op
+	}
+
+	public void MethodThree(int zulu, int alpha)
+	{
+		// No-op
+	}
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -28,14 +28,29 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 		=> CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(descriptor);
 
 	/// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
-	public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+	public static async Task VerifyAnalyzerAsync(
+		string source,
+		DiagnosticResult[]? expected = null,
+		ICollection<string>? disabledDiagnostics = null,
+		ICollection<(string filename, string fileContent)>? analyzerConfigFiles = null)
 	{
 		var test = new Test
 		{
 			TestCode = source,
 		};
 
-		test.ExpectedDiagnostics.AddRange(expected);
+		if (disabledDiagnostics is not null)
+		{
+			test.DisabledDiagnostics.AddRange(disabledDiagnostics);
+		}
+
+		if (analyzerConfigFiles is not null)
+		{
+			foreach (var (filename, fileContent) in analyzerConfigFiles)
+				test.TestState.AnalyzerConfigFiles.Add((filename, fileContent));
+		}
+
+		test.ExpectedDiagnostics.AddRange(expected ?? []);
 		await test.RunAsync(CancellationToken.None);
 	}
 
@@ -52,6 +67,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 		string source,
 		DiagnosticResult[] expected,
 		string fixedSource,
+		ICollection<string>? disabledDiagnostics = null,
 		ICollection<(string filename, string fileContent)>? analyzerConfigFiles = null)
 	{
 		var test = new Test
@@ -59,6 +75,11 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 			TestCode = source,
 			FixedCode = fixedSource,
 		};
+
+		if (disabledDiagnostics is not null)
+		{
+			test.DisabledDiagnostics.AddRange(disabledDiagnostics);
+		}
 
 		if (analyzerConfigFiles is not null)
 		{


### PR DESCRIPTION
- Update RBCS0001 analyzer logic to ignore a primary construct, if present, in the group ordering
- Fix a potential sequence contains no elements error
- Add new rule RBCS0004 (disabled by default) and fixer to allow automatic ordering of enum member names alphabetically separately from RBCS0002
- Add new rule RBCS0005 (disabled by default) and fixer to allow automatic ordering of method and constructor parameter names