### PR TITLE
RBCS0001 and RBCS0002 Fixes

### DIFF
--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/MembersOrderedCorrectlyAnalyzerCodeFixProvider.cs
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.CodeFixes/MembersOrderedCorrectlyAnalyzerCodeFixProvider.cs
@@ -500,6 +500,16 @@ public class MembersOrderedCorrectlyAnalyzerCodeFixProvider : CodeFixProvider
 
 				if (memberSymbol is null)
 				{
+					var isPartial = memberSyntax.Modifiers.Any(modifierToken => modifierToken.ValueText == "partial");
+					if (isPartial)
+					{
+						memberSymbol ??= semanticModel.GetSymbolInfo(memberSyntax, cancellationToken).Symbol;
+						memberSymbol ??= semanticModel.GetDeclaredSymbol(memberSyntax, cancellationToken);
+					}
+				}
+
+				if (memberSymbol is null)
+				{
 					sortedMembers.Add(new SortedMemberKey(null, memberCount++), memberSyntax);
 					continue;
 				}

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Package/Rhinobyte.CodeAnalysis.NetAnalyzers.Package.csproj
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Package/Rhinobyte.CodeAnalysis.NetAnalyzers.Package.csproj
@@ -10,7 +10,9 @@
 
         <!-- VERSION VALUES -->
         <PackageId>Rhinobyte.CodeAnalysis.NetAnalyzers</PackageId>
-        <PackageVersion>1.0.0.0-preview.6</PackageVersion>
+        
+        <PackageVersion>1.0.0.0-preview.7</PackageVersion>
+
         <Authors>Ryan Thomas</Authors>
         <Company>Rhinobyte Software</Company>
         <Copyright>Copyright © Ryan Thomas. All rights reserved.</Copyright>
@@ -36,31 +38,9 @@
 
         <Description>Rhinobyte.CodeAnalysis.NetAnalyzers</Description>
         <PackageReleaseNotes>
-            v1.0.0.0-preview.6
-            - Update analyzer for RBCS0001 to ignore a primary constructor when determining if member groups are ordered correctly
-            - Fix bug that would result in a sequence contains no elements exception when the MembersOrderedCorrectlyAnalyzer was run on an enum type declaration
-            - Add new rule RBCS0004: Order enum member names alphabetically
-            - Add new rule RBCS0005: Order enum member values in ascending order
-            
-            v1.0.0.0-preview.5
-            - Add new rule RBCS0010: Arguments for optional parameters should be passed explicitly by name
-
-            v1.0.0-beta.4
-            - Updated nuget package dependencies to latest versions
-            - Resolved analyzer warnings for newer analyzer rules
-            - Updated the MembersOrderedCorrectlyAnalyzerCodeFixProvider to use a class type in lieu of struct type for sort member key data to reduce possibility of a stack overflow exception in really big files
-
-            v1.0.0-beta.3
-            - Fixed the url used in the analzyer rule help links to point to the https://github.com/RhinobyteSoftware/dotnet-tools/blob/main/docs/codeanalysis/rules/ folder
-            - Updated the README.md that is included in the package to include the list of rules from the AnalyzerReleases.Shipped.md file and to use absolute urls for the rule docs pointed at the github repo
-
-            v1.0.0-beta.2
-            - Updated the MembersOrderedCorrectly analyzer and code fix provider to support configuration via .EditorConfig properties
-            - Added new rule RBCS0003: Member assignments in an object initializer are ordered correctly
-
-            v1.0.0-beta.1
-            - Added new MembersOrderedCorrectlyAnalyzer and MembersOrderedCorrectlyAnalyzerCodeFixProvider
-            with rules RBCS0001: Type members should be ordered by group and RBCS0002: Type members within the same group should be ordered correctly
+            v1.0.0.0-preview.7
+            - Update analzyer for RBCS0001 to ignore primary constructor when the type is a partial class
+            - Update the MembersOrderedCorrectlyAnalyzerCodeFixProvider to correctly sort both the declaration and definition of partial methods
         </PackageReleaseNotes>
         <PackageTags>Rhinobyte.CodeAnalysis.NetAnalyzers, analyzers</PackageTags>
         <DevelopmentDependency>true</DevelopmentDependency>

--- a/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/MembersOrderedCorrectlyAnalyzer.cs
+++ b/src/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers/MembersOrderedCorrectlyAnalyzer.cs
@@ -191,6 +191,15 @@ public class MembersOrderedCorrectlyAnalyzer : DiagnosticAnalyzer
 			if (!memberSymbol.CanBeReferencedByName && currentMemberGroupType != MemberGroupType.Constructors && currentMemberGroupType != MemberGroupType.StaticConstructors)
 				continue;
 
+			if (currentMemberGroupType == MemberGroupType.Constructors)
+			{
+				var declaringSyntax = memberSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(context.CancellationToken);
+				var isPrimaryConstructor = declaringSyntax is ClassDeclarationSyntax;
+
+				if (isPrimaryConstructor)
+					continue;
+			}
+
 			foreach (var memberLocation in memberSymbol.Locations)
 			{
 				var memberLocationLineSpan = memberLocation.GetLineSpan();

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/MembersOrderedCorrectlyAnalyzerCodeFixProviderUnitTests.cs
@@ -177,4 +177,22 @@ dotnet_diagnostic.RBCS0003.severity = none
 
 		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult, analyzerConfigFiles: editorConfigSettings);
 	}
+
+	[TestMethod]
+	public async Task MembersOrderedCorrectlyCodeFixer_works_with_primary_constructor_partial_classes()
+	{
+		var testContent = await TestHelper.GetTestInputFileAsync(CancellationTokenForTest);
+		var codeFixResult = await TestHelper.GetTestCodeFixResultFileAsync(CancellationTokenForTest);
+
+		var expectedDiagnosticResults = new DiagnosticResult[]
+		{
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0001).WithSpan(16, 34, 16, 50).WithArguments("TimeSpanConstant"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0001).WithSpan(18, 21, 18, 35).WithArguments("StaticProperty"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0001).WithSpan(25, 22, 25, 33).WithArguments("ConstantOne"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0001).WithSpan(30, 14, 30, 23).WithArguments("PropertyA"),
+			VerifyCS.Diagnostic(MembersOrderedCorrectlyAnalyzer.RBCS0001).WithSpan(37, 23, 37, 30).WithArguments("_field2"),
+		};
+
+		await VerifyCS.VerifyCodeFixAsync(testContent, expectedDiagnosticResults, codeFixResult);
+	}
 }

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_works_with_primary_constructor_partial_classes.codefixresult.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_works_with_primary_constructor_partial_classes.codefixresult.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public partial class PartialClassWithPrimaryConstructor(
+	string primaryConstructorParam1,
+	string primaryConstructorParam2)
+{
+	public const string ConstantOne = nameof(ConstantOne);
+
+	public static readonly TimeSpan TimeSpanConstant = TimeSpan.FromMinutes(1);
+
+	public static bool StaticProperty { get; } = true;
+
+    private readonly int _field1;
+
+	public PartialClassWithPrimaryConstructor()
+		: this(string.Empty, string.Empty)
+	{
+
+	}
+
+	public bool PropertyA { get; set; }
+
+	//[GeneratedRegex("\\s+")]
+	private static partial Regex WhitespacePattern();
+}
+
+partial class PartialClassWithPrimaryConstructor
+{
+
+	private readonly int _field2;
+
+    public string PropertyB { get; set; }
+
+	public static async Task DoSomethingAsync(CancellationToken cancellationToken)
+	{
+		await Task.Delay(1_000, cancellationToken);
+	}
+
+	private static partial Regex WhitespacePattern()
+	{
+		return new Regex("\\s+");
+	}
+}

--- a/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_works_with_primary_constructor_partial_classes.input.cs
+++ b/tests/CodeAnalysis/Rhinobyte.CodeAnalysis.NetAnalyzers.Tests/TestCaseFiles/MembersOrderedCorrectlyCodeFixer_works_with_primary_constructor_partial_classes.input.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.CodeAnalysis.NetAnalyzers.Tests.TestCaseFiles;
+
+public partial class PartialClassWithPrimaryConstructor(
+	string primaryConstructorParam1,
+	string primaryConstructorParam2)
+{
+	private readonly int _field1;
+
+	public static readonly TimeSpan TimeSpanConstant = TimeSpan.FromMinutes(1);
+
+	public static bool StaticProperty { get; } = true;
+
+	public PartialClassWithPrimaryConstructor()
+		: this(string.Empty, string.Empty)
+	{
+
+	}
+	public const string ConstantOne = nameof(ConstantOne);
+
+	//[GeneratedRegex("\\s+")]
+	private static partial Regex WhitespacePattern();
+
+	public bool PropertyA { get; set; }
+}
+
+partial class PartialClassWithPrimaryConstructor
+{
+	public string PropertyB { get; set; }
+
+	private readonly int _field2;
+
+	public static async Task DoSomethingAsync(CancellationToken cancellationToken)
+	{
+		await Task.Delay(1_000, cancellationToken);
+	}
+
+	private static partial Regex WhitespacePattern()
+	{
+		return new Regex("\\s+");
+	}
+}


### PR DESCRIPTION
- Update MembersOrderedCorrectlyAnalyzer to also skip primary constructors when analyzing partial classes
- Update MembersOrderedCorrectlyAnalyzerCodeFixProvider to account for partial methods where the declaration and definition only appear as a single member symbol
- Update code analyzer package version to v1.0.0-preview-7